### PR TITLE
Basic URL API

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"go-url-shortener/internal/routes"
+	"net/http"
+)
+
+func main() {
+	router := routes.NewRouter()
+
+	fmt.Println("Server is listening")
+	err := http.ListenAndServe(":8080", router)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-	store := make(map[string]string)
+	store := make(map[string]*routes.SavedLinks)
 
 	server := &routes.Server{DataStore: store}
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -7,7 +7,12 @@ import (
 )
 
 func main() {
-	router := routes.NewRouter()
+
+	store := make(map[string]string)
+
+	server := &routes.Server{DataStore: store}
+
+	router := server.NewRouter()
 
 	fmt.Println("Server is listening")
 	err := http.ListenAndServe(":8080", router)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go-url-shortener
+
+go 1.23.6

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1,0 +1,24 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func NewRouter() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", indexHandler)
+	mux.HandleFunc("/api/data", apiDataHandler)
+
+	return mux
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "Welcome!")
+}
+
+func apiDataHandler(w http.ResponseWriter, r *http.Request) {
+	data := "Data..."
+	fmt.Fprintln(w, data)
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -2,14 +2,21 @@ package routes
 
 import (
 	"fmt"
+	"io"
+	"math/rand"
 	"net/http"
 )
 
-func NewRouter() http.Handler {
+type Server struct {
+	DataStore map[string]string
+}
+
+func (s *Server) NewRouter() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/", indexHandler)
 	mux.HandleFunc("/api/data", apiDataHandler)
+	mux.HandleFunc("/api/shorten", s.apiShortenLink)
 
 	return mux
 }
@@ -21,4 +28,41 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 func apiDataHandler(w http.ResponseWriter, r *http.Request) {
 	data := "Data..."
 	fmt.Fprintln(w, data)
+}
+
+func (s *Server) apiShortenLink(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Invalid method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	shortLink, exists := s.DataStore[string(body)]
+
+	if !exists {
+		shortLink = shortenURL()
+		s.DataStore[string(body)] = shortLink
+	}
+
+	response := fmt.Sprintf("Shortened link: %s", shortLink)
+
+	fmt.Fprintln(w, response)
+}
+
+func shortenURL() string {
+	return RandString(5)
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyz1234567890"
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
**URL API that can:**
- Call _api/shorten_, with an URL as input, return a shortened URL path.
- Call _/{shortenedPath}_, to get redirected to the original input.
- Call _stats/{shortenedPath}_, to see how many times a shortened link has been clicked.

Shortened URLs are stored in maps.
ShortURL -> {Original URL, Click statistics}